### PR TITLE
Add workaround to access property from Objective-C

### DIFF
--- a/ISScrollViewPage/ISScrollViewPage/ISScrollViewPage.swift
+++ b/ISScrollViewPage/ISScrollViewPage/ISScrollViewPage.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-public enum ISScrollViewPageType {
-    case ISScrollViewPageHorizontally
+@objc public enum ISScrollViewPageType:Int {
+    case ISScrollViewPageHorizontally = 1
     case ISScrollViewPageVertically
 }
 
@@ -28,7 +28,19 @@ public class ISScrollViewPage: UIScrollView, UIScrollViewDelegate {
     var enablePaging:Bool?
     var fillContent:Bool?
     var scrollViewPageType:ISScrollViewPageType!
+
     var isLoaded:Bool!
+
+    public func getScrollViewPageTypeFromInt(value:Int) -> ISScrollViewPageType {
+        switch(value) {
+        case 1:
+            return .ISScrollViewPageHorizontally
+        case 2:
+            return .ISScrollViewPageVertically
+        default:
+            return .ISScrollViewPageHorizontally
+        }
+    }
     
     //MARK: Life Cycle
     
@@ -178,6 +190,10 @@ public class ISScrollViewPage: UIScrollView, UIScrollViewDelegate {
     
     public func setPaging(pagingEnabled:Bool){
         self.enablePaging = pagingEnabled
+    }
+
+    public func setScrollViewPageType(value:Int) {
+        self.scrollViewPageType = getScrollViewPageTypeFromInt(value);
     }
     
     //MARK: Private Functions


### PR DESCRIPTION
Add a setScrollViewPageType to set the property as an int instead of the
ENUM type.
